### PR TITLE
Add component icons to ACCESS-AM

### DIFF
--- a/docs/configurations/access-am.md
+++ b/docs/configurations/access-am.md
@@ -1,5 +1,8 @@
 # ACCESS-AM {{ supp }}
 
+![Atmosphere Component Logo](../assets/component-logos/ACCESS-icon-ATMOSPHERE-300x300.png){align=right width=40%}
+![Land Component Logo](../assets/component-logos/ACCESS-icon-LAND-SURFACE-300x300.png){align=right width=40%}
+
 {% include "call_contribute.md" %}
 
 The ACCESS-AM model is a coupled model between the atmosphere and the land. The atmospheric model component is the [UM model][UM-hive]. The UM model comes by default coupled to the [JULES][JULES-hive] land model. That is why the first configurations and experiments released of ACCESS-AM will be UM-JULES configurations. But the ACCESS-NRI is working to ensure subsequent releases of ACCESS-AM use the [CABLE][CABLE-hive] land model instead.


### PR DESCRIPTION
It would be nice to link the configuration and component pages by displaying what components get used in each visually

(testing contribution process)

# ACCESS Community Hive 

Thank you for submitting a pull request to the ACCESS Hive Project. 

## Description

Please include a brief summary of the change and list the issues that are fixed.
Please also include relevant motivation and context.

You can link issues by using a supported keyword in the pull request's description or in a commit message:

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue, e.g. dead links)
- [ ] New link / content

## Checklist:

- [ ] The new content is accessible and located in the appropriate section.
- [ ] My changes do not break navigation and do not generate new warnings
- [ ] I have checked that the links are valid and point to the intended content.
- [ ] I have checked my code/text and corrected any misspellings

Please tag the **reviewers team** in a comment below by prepending an `@` in front of `ACCESS-Hive/reviewers` when ready.
