### PR TITLE
Trigger the preview build when labeled

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,8 +3,7 @@ name: Deploy PR preview
 on:
   pull_request:
     types:
-      - opened
-      - reopened
+      - labeled
       - synchronize
       - closed
 
@@ -28,6 +27,7 @@ permissions:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -46,6 +46,6 @@ jobs:
           mkdocs build -f mkdocs.yml -d site
 
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: access-nri/pr-preview-action@v1.1
         with:
           source-dir: site

--- a/docs/about/contribute.md
+++ b/docs/about/contribute.md
@@ -78,9 +78,9 @@ When you click on this icon, your browser will open the file in GitHub allowing 
     The `main` branch of the repository is protected and nobody can write to it directly. You will need to choose either to create a new branch and open a pull request if you are a member of ACCESS-Hive organisation, or to create a fork on your personal account and open a pull request if you are not a member of ACCESS-Hive organisation.
     ![BranchAndPR](../assets/branch-and-pr.png)
 
-When creating the pull request, make sure to add the text: `Closes #X` to the description, where X is the issue number related to this change. This will link the pull request and the issue together and the issue will be automatically closed once the pull request is accepted. The pull request will also automatically build [a preview of the documentation with your proposed changes][preview].
+When creating the pull request, make sure to add the text: `Closes #X` to the description, where X is the issue number related to this change. This will link the pull request and the issue together and the issue will be automatically closed once the pull request is accepted. 
 
-Then ask for a review by tagging the `@ACCESS-Hive/reviewers` team in a comment.
+Then ask for a review by tagging the `@ACCESS-Hive/reviewers` team in a comment. Once the pull request is being reviewed, the reviewer will trigger [a preview of the documentation with your proposed changes][preview].
 
 You will be notified by email of any subsequent comment, request or action from the reviewer on this pull request. Please make sure you take any action required by the reviewer or your modification will not be accepted into the ACCESS-Hive site. 
 
@@ -127,7 +127,7 @@ Your documentation will be built on http://127.0.0.1:8000. Open this URL in your
 
 ### Preview of the documentation
 
-When a pull request is opened or updated, GitHub will automatically build a preview of the documentation that includes the proposed changes. This can be used instead of local updates by setting your pull request as a draft for example.
+When a pull request is labeled during the review process, GitHub will automatically build a preview of the documentation that includes the proposed changes. The preview will not build until a reviewer has labeled the pull request as safe to test.
 
 In the pull request, you will see the link to the preview appear in this fashion:
 


### PR DESCRIPTION
# ACCESS Community Hive 

Thank you for submitting a pull request to the ACCESS Hive Project. 

## Description

This allows the preview to be built from forks after a human review of the proposed changes. 

Note, the preview will never build automatically on creation of the PR even if the PR is from a local branch. It always needs the label to be applied to the PR in order to run.  

I have also updated the corresponding text in the contribution guide. 

Fixes #121

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [X] The new content is accessible and located in the appropriate section.
- [X] My changes do not break navigation and do not generate new warnings
- [X] I have checked that the links are valid and point to the intended content.
- [X] I have checked my code/text and corrected any misspellings

Please tag the **reviewers team** in a comment below by prepending an `@` in front of `ACCESS-Hive/reviewers` when ready.
