### PR TITLE
Forgot to change the trigger event

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
+    if: contains(github.event.pull_request.labels.*.name, 'safe')
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,7 +1,7 @@
 name: Deploy PR preview
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
       - synchronize


### PR DESCRIPTION
# ACCESS Community Hive 

Thank you for submitting a pull request to the ACCESS Hive Project. 

## Description

Please include a brief summary of the change and list the issues that are fixed.
Please also include relevant motivation and context.

You can link issues by using a supported keyword in the pull request's description or in a commit message:

Fixes #121  (again)

Forgot to change the triggering event from `pull_request` to `pull_request_target` the first time around.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [X] The new content is accessible and located in the appropriate section.
- [X] My changes do not break navigation and do not generate new warnings
- [X] I have checked that the links are valid and point to the intended content.
- [X] I have checked my code/text and corrected any misspellings

Please tag the **reviewers team** in a comment below by prepending an `@` in front of `ACCESS-Hive/reviewers` when ready.
