### PR TITLE
New preview workflow to work on external forks

### DIFF
--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -48,3 +48,4 @@ jobs:
         with:
           name: pr_site
           path: pr_site/
+          

--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -1,33 +1,19 @@
-name: Deploy PR preview
+name: Build PR preview
 
 on:
   pull_request:
     types:
-      - labeled
+      - opened
+      - reopened
       - synchronize
-      - closed
 
 concurrency: 
   group: preview-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  actions: write
-  checks: write
-  contents: write
-  deployments: write
-  issues: write
-  packages: write
-  pull-requests: write
-  pages: write
-  repository-projects: write
-  security-events: write
-  statuses: write
-
 jobs:
-  deploy-preview:
+  build-preview:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,7 +31,20 @@ jobs:
         run: |
           mkdocs build -f mkdocs.yml -d site
 
-      - name: Deploy preview
-        uses: access-nri/pr-preview-action@v1.1
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NB
+      - uses: actions/upload-artifact@v2
         with:
-          source-dir: site
+          name: pr
+          path: pr/
+
+      - name: Save built site
+        run: |
+          mkdir -p ./pr_site
+          mv site ./pr_site/.
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr_site
+          path: pr_site/

--- a/.github/workflows/clean_preview.yml
+++ b/.github/workflows/clean_preview.yml
@@ -1,0 +1,51 @@
+name: Clean PR preview
+
+on:
+  workflow_run:
+    workflows: ["Close PR"]
+    types:
+      - completed
+
+jobs:
+  close-preview:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: "Download PR number"
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "prnumber"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/prnumber.zip', Buffer.from(download.data));
+      - run: |
+          unzip prnumber.zip
+          echo "pr-number=$(cat prnumber.txt)" >> "$GITHUB_ENV"
+        shell: bash
+ 
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Clean preview
+        uses: access-nri/pr-preview-action@v2
+        with:
+          action: remove
+          pr-number: ${{ env.pr-number }}

--- a/.github/workflows/clean_preview.yml
+++ b/.github/workflows/clean_preview.yml
@@ -49,3 +49,4 @@ jobs:
         with:
           action: remove
           pr-number: ${{ env.pr-number }}
+          

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -1,0 +1,19 @@
+name: Close PR
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  send-number:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        run: |
+          mkdir -p ./prnumber
+          echo ${{ github.event.number }} > ./prnumber/prnumber.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: prnumber
+          path: prnumber/

--- a/.github/workflows/close_pr.yml
+++ b/.github/workflows/close_pr.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           name: prnumber
           path: prnumber/
+          

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -73,3 +73,4 @@ jobs:
           source-dir: site
           action: deploy
           pr-number: ${{ env.pr-number }}
+          

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,0 +1,75 @@
+name: Deploy PR preview
+
+on:
+  workflow_run:
+    workflows: ["Build PR preview"]
+    types:
+      - completed
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: "Download PR number"
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: |
+          unzip pr.zip
+          echo "pr-number=$(cat NB)" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: "Download built site"
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_site"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr_site.zip', Buffer.from(download.data));
+      - run: unzip pr_site.zip
+
+      - name: Deploy preview
+        uses: access-nri/pr-preview-action@v2
+        with:
+          source-dir: site
+          action: deploy
+          pr-number: ${{ env.pr-number }}

--- a/docs/about/contribute.md
+++ b/docs/about/contribute.md
@@ -78,9 +78,9 @@ When you click on this icon, your browser will open the file in GitHub allowing 
     The `main` branch of the repository is protected and nobody can write to it directly. You will need to choose either to create a new branch and open a pull request if you are a member of ACCESS-Hive organisation, or to create a fork on your personal account and open a pull request if you are not a member of ACCESS-Hive organisation.
     ![BranchAndPR](../assets/branch-and-pr.png)
 
-When creating the pull request, make sure to add the text: `Closes #X` to the description, where X is the issue number related to this change. This will link the pull request and the issue together and the issue will be automatically closed once the pull request is accepted. 
+When creating the pull request, make sure to add the text: `Closes #X` to the description, where X is the issue number related to this change. This will link the pull request and the issue together and the issue will be automatically closed once the pull request is accepted. The pull request will also automatically build [a preview of the documentation with your proposed changes][preview].
 
-Then ask for a review by tagging the `@ACCESS-Hive/reviewers` team in a comment. Once the pull request is being reviewed, the reviewer will trigger [a preview of the documentation with your proposed changes][preview].
+Then ask for a review by tagging the `@ACCESS-Hive/reviewers` team in a comment. 
 
 You will be notified by email of any subsequent comment, request or action from the reviewer on this pull request. Please make sure you take any action required by the reviewer or your modification will not be accepted into the ACCESS-Hive site. 
 
@@ -127,14 +127,14 @@ Your documentation will be built on http://127.0.0.1:8000. Open this URL in your
 
 ### Preview of the documentation
 
-When a pull request is labeled during the review process, GitHub will automatically build a preview of the documentation that includes the proposed changes. The preview will not build until a reviewer has labeled the pull request as safe to test.
+When a pull request is created or updated, GitHub will automatically build a preview of the documentation that includes the proposed changes. 
 
 In the pull request, you will see the link to the preview appear in this fashion:
 
 ![PRpreview](../assets/site-preview-PR.png)
 
 ???+ info "Build delay"
-    It can take a while for the preview to build.
+    It can take a while for the preview to build, even after the CI check is indicated as finished. Please wait for the comment with the link to appear and allow for some time after that for the preview to be properly deployed.
 
     If you open the preview and it looks completely broken or if it hasn't updated from additional modifications in the pull request, it probably means the site hasn't finished building yet. If you wait a little bit and refresh the page, it should fix it.
 


### PR DESCRIPTION
# ACCESS Community Hive 

Thank you for submitting a pull request to the ACCESS Hive Project. 

## Description

Please include a brief summary of the change and list the issues that are fixed.
Please also include relevant motivation and context.

You can link issues by using a supported keyword in the pull request's description or in a commit message:

Fixes #121

Based on https://securitylab.github.com/research/github-actions-preventing-pwn-requests/, we split the preview workflow in 2 steps: the first builds the site securely and the second deploys the site preview.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [X] The new content is accessible and located in the appropriate section.
- [X] I have checked my code/text and corrected any misspellings

Please tag the **reviewers team** in a comment below by prepending an `@` in front of `ACCESS-Hive/reviewers` when ready.
