### PR TITLE
Training: review organisation from soft launch feedback

### DIFF
--- a/docs/docs_and_training/technical.md
+++ b/docs/docs_and_training/technical.md
@@ -1,9 +1,0 @@
-# Technical trainings
-
-## [Git and GitHub][GitAndGitHub]
-
-**Domain**: Technical
-
-To learn the basics of Git and GitHub. It also includes ACCESS-NRI's recommendations to setup GitHub. 
-
-[GitAndGitHub]: https://access-nri.github.io/Training/HowTos/GitAndGitHub/basics/

--- a/docs/training_and_policies/ACCESS_training.md
+++ b/docs/training_and_policies/ACCESS_training.md
@@ -1,0 +1,7 @@
+# ACCESS training material
+
+This page is intended to provide access to training material directly related to ACCESS models and model components. This material can cover topics such as but not limited to:
+
+ - how to use a specific model
+ - how to modify a model configuration
+ - how to test a model modification or validate a model run

--- a/docs/training_and_policies/additional_training.md
+++ b/docs/training_and_policies/additional_training.md
@@ -1,18 +1,11 @@
-# Documentation and Training
+# Additional training material
 
-{% include "call_contribute.md" %}
+## [Git and GitHub][GitAndGitHub] {{ supp }}
 
-???+ info
-    **What to expect in the next few months?**
+To learn the basics of Git and GitHub. It also includes ACCESS-NRI's recommendations to setup GitHub. 
 
-    - The ACCESS-NRI Training Team will developed and release training materials for supported Models, Model Components and Configurations.
-    - The Model Evaluation and Diagnostics Team (MED) will recommend tools and workflows for processing and evaluating model outputs.
 
-    ACCESS-NRI will organise regular workshops around the ACCESS suite of supported products. We will also support community workshops to address specific needs. 
-    We encourage the members of the community to [contact us](mailto:access.nri@anu.edu.au) and welcome their suggestions. 
-
-## Training resources from partners {{ recom }}
-
+## [NCI training][nci-training] {{ recom }}
 <div class="result" markdown>
 
 ![NCI Logo](../assets/nci_logo_color.svg){align=right width=40%}
@@ -25,6 +18,7 @@ A full calendar of upcoming training opportunities can be found on their [Opus p
 
 Users can find important information and resources about using NCI systems and services in the [NCI User Guides][nci-user-guides].
 
+[GitAndGitHub]: https://access-nri.github.io/Training/HowTos/GitAndGitHub/basics/
 [nci-web]: https://www.nci.org.au
 [nci-training]: https://www.nci.org.au/users/user-training
 [opus-web]: https://opus.nci.org.au/display/Help/NCI+Training+and+Educational+Events

--- a/docs/training_and_policies/index.md
+++ b/docs/training_and_policies/index.md
@@ -1,0 +1,22 @@
+# Training and Policies
+
+{% include "call_contribute.md" %}
+
+This space is intended to promote training material relevant to ACCESS and its community. The training material can be directly relevant to ACCESS and its model components, such as:
+
+- using coupled models and model components
+- using configurations
+- using model evaluation tools and workflows
+
+It is also intended for training material around more peripheral topics that are essential for the community, such as:
+
+- HPC
+- version control
+- essential software packages
+
+ACCESS-NRI encourages the members of the community to [contact us](mailto:access.nri@anu.edu.au) to share their suggestions.
+
+
+Finally, you will also find [ACCESS-NRI's policies][policies] in this space.
+
+[policies]: policies.md

--- a/docs/training_and_policies/policies.md
+++ b/docs/training_and_policies/policies.md
@@ -1,4 +1,4 @@
-# Policies
+# Policies {{ supp }}
 
 - [Procedures and Practices][pandp]: Contains documents outlining how ACCESS-NRI will function. These documents describe what users can expect and justifications for the decisions against criteria that are based on the values of the organisation.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,10 +85,11 @@ nav:
     - Biogeochemistry Ocean: model_evaluation/bgc_ocean.md
     - Data processing: model_evaluation/data_processing.md
     - Data catalogs: model_evaluation/data_catalogs.md
-  - Documentation & Training: 
-    - docs_and_training/index.md
-    - Policies : docs_and_training/policies.md
-    - Technical: docs_and_training/technical.md
+  - Training & Policies: 
+    - training_and_policies/index.md
+    - ACCESS training: training_and_policies/ACCESS_training.md
+    - Additional training: training_and_policies/additional_training.md
+    - Policies: training_and_policies/policies.md
   - Working Groups:
     - working_groups/index.md
 


### PR DESCRIPTION
# ACCESS Community Hive 

Thank you for submitting a pull request to the ACCESS Hive Project. 

## Description

Fixes #136

I have done a more thorough review of the tab content and organisation than originally highlighted in the issue.

1. Rename. I don't like the word "Documentation" here as the whole Hive is documentation
2. Remove the box in index.md. The box would need to be updated in the future as content comes in. Replaced by text that is intended to stay over a longer term
3. Separate trainings. I've put a page for ACCESS-specific training and other peripheral trainings. So I moved the NCI training in the additional training and put with the Git/GitHub training.

Happy to get feedback on these choices.

## Type of change

Please delete options that are not relevant.

- [X] New link / content

## Checklist:

- [X] The new content is accessible and located in the appropriate section.
- [X] My changes do not break navigation and do not generate new warnings
- [X] I have checked that the links are valid and point to the intended content.
- [X] I have checked my code/text and corrected any misspellings

Please tag the **reviewers team** in a comment below by prepending an `@` in front of `ACCESS-Hive/reviewers` when ready.
