### PR TITLE
Move  requirements into file to abstract actions

### DIFF
--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -23,8 +23,7 @@ jobs:
           python-version: 3.x
 
       - name: Install dependencies
-        run: | 
-          pip install mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-macros-plugin
+        run: pip install -r requirements.txt
 
       - name: Build
         # builds to "site" directory by default

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,7 @@ jobs:
           python-version: 3.x
 
       - name: Install dependencies
-        run: | 
-          pip install mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-macros-plugin
-
+        run:  pip install -r requirements.txt
       - name: Build
         run: |
           mkdocs build -f mkdocs.yml -d site

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs-material>=7.2.6
+mkdocs-git-revision-date-localized-plugin
+mkdocs-macros-plugin
+git+https://github.com/rbeucher/mkdocs_events_plugin.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 mkdocs-material>=7.2.6
 mkdocs-git-revision-date-localized-plugin
 mkdocs-macros-plugin
-git+https://github.com/rbeucher/mkdocs_events_plugin.git


### PR DESCRIPTION
I moved the requirements into a text file. That way this generalise the actions a bit more.
As it is currently we can't test the preview if we add new requirements
The PR should fix this.